### PR TITLE
Reset default height setting for better embedding of plots into docum…

### DIFF
--- a/django_comparison_dashboard/settings.py
+++ b/django_comparison_dashboard/settings.py
@@ -37,7 +37,6 @@ GRID_COLOR = "lightgray"
 GRAPHS_DEFAULT_TEMPLATE = "plotly_white"
 GRAPHS_DEFAULT_LAYOUT = {
     "legend": {"font": {"size": 14}},
-    "height": 700,
 }
 GRAPHS_DEFAULT_XAXES_LAYOUT = {
     "autorange": True,


### PR DESCRIPTION
While the fixed height was good to use more of the page size for barcharts, it led to problems in the documentation when embedding the plots. Therefore, the fixed height has been removed again.